### PR TITLE
replace deprecated String.prototype.substr()

### DIFF
--- a/src/pDate.js
+++ b/src/pDate.js
@@ -83,7 +83,7 @@ class PersianDateClass {
         }
         // ASP.NET JSON Date
         else if (input && input.substring(0, 6) === '/Date(') {
-            const fromDotNet = new Date(parseInt(input.substr(6)));
+            const fromDotNet = new Date(parseInt(input.slice(6)));
             this._gDateToCalculators(fromDotNet);
         }
         else {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.